### PR TITLE
Add collectors about network

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ all:
 
 test:
 	go test
-	cd hostname && go test
-	cd cpu      && go test
-	cd memory   && go test
+	cd hostname    && go test
+	cd cpu         && go test
+	cd memory      && go test
+	cd ipaddress   && go test

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,11 @@ all:
 
 test:
 	go test
-	cd hostname    && go test
-	cd env         && go test
 	cd cpu         && go test
-	cd memory      && go test
+	cd env         && go test
+	cd hostname    && go test
 	cd ipaddress   && go test
+	cd ipv6address && go test
+	cd macaddress  && go test
+	cd memory      && go test
+	cd network     && go test

--- a/collector.go
+++ b/collector.go
@@ -5,7 +5,10 @@ import (
 	"github.com/kentaro/verity/env"
 	"github.com/kentaro/verity/hostname"
 	"github.com/kentaro/verity/ipaddress"
+	"github.com/kentaro/verity/ipv6address"
+	"github.com/kentaro/verity/macaddress"
 	"github.com/kentaro/verity/memory"
+	"github.com/kentaro/verity/network"
 	"log"
 )
 
@@ -17,9 +20,12 @@ type Collector interface {
 var collectors = []Collector{
 	&cpu.Cpu{},
 	&env.Env{},
-	&memory.Memory{},
-	&ipaddress.IpAddress{},
 	&hostname.Hostname{},
+	&ipaddress.IpAddress{},
+	&ipv6address.Ipv6Address{},
+	&macaddress.MacAddress{},
+	&memory.Memory{},
+	&network.Network{},
 }
 
 func Collect() (result map[string]interface{}, err error) {

--- a/collector.go
+++ b/collector.go
@@ -3,6 +3,7 @@ package verity
 import (
 	"github.com/kentaro/verity/cpu"
 	"github.com/kentaro/verity/hostname"
+	"github.com/kentaro/verity/ipaddress"
 	"github.com/kentaro/verity/memory"
 	"log"
 )
@@ -16,6 +17,7 @@ var collectors = []Collector{
 	&hostname.Hostname{},
 	&cpu.Cpu{},
 	&memory.Memory{},
+	&ipaddress.IpAddress{},
 }
 
 func Collect() (result map[string]interface{}, err error) {

--- a/ipaddress/ipaddress.go
+++ b/ipaddress/ipaddress.go
@@ -1,0 +1,59 @@
+package ipaddress
+
+import (
+	"errors"
+	"net"
+)
+
+type IpAddress struct{}
+
+const name = "ipaddress"
+
+func (self *IpAddress) Name() string {
+	return name
+}
+
+func (self *IpAddress) Collect() (result interface{}, err error) {
+	ipaddress, err := externalIP()
+	result = ipaddress
+
+	return
+}
+
+func externalIP() (string, error) {
+	ifaces, err := net.Interfaces()
+
+	if err != nil {
+		return "", err
+	}
+
+	for _, iface := range ifaces {
+		if iface.Flags&net.FlagUp == 0 || iface.Flags&net.FlagLoopback != 0 {
+			// interface down or loopback interface
+			continue
+		}
+		addrs, err := iface.Addrs()
+		if err != nil {
+			return "", err
+		}
+		for _, addr := range addrs {
+			var ip net.IP
+			switch v := addr.(type) {
+			case *net.IPNet:
+				ip = v.IP
+			case *net.IPAddr:
+				ip = v.IP
+			}
+			if ip == nil || ip.IsLoopback() {
+				continue
+			}
+			ip = ip.To4()
+			if ip == nil {
+				// not an ipv4 address
+				continue
+			}
+			return ip.String(), nil
+		}
+	}
+	return "", errors.New("not connected to the network")
+}

--- a/ipaddress/ipaddress_test.go
+++ b/ipaddress/ipaddress_test.go
@@ -5,22 +5,12 @@ import (
 	"testing"
 )
 
-func TestHostname(t *testing.T) {
+func TestIpAddress(t *testing.T) {
 	Describe(t, "ipaddress.Name", func() {
 		collector := &IpAddress{}
 
 		It("should have its own name", func() {
 			Expect(collector.Name()).To(Equal, "ipaddress")
-		})
-	})
-
-	Describe(t, "verity.Collector.IpAddress.Collect", func() {
-		collector := &IpAddress{}
-		result, _ := collector.Collect()
-		ipaddress := "10.0.2.15"
-
-		It("should be able to collect ipaddress", func() {
-			Expect(result.(string)).To(Equal, ipaddress)
 		})
 	})
 }

--- a/ipaddress/ipaddress_test.go
+++ b/ipaddress/ipaddress_test.go
@@ -1,0 +1,26 @@
+package ipaddress
+
+import (
+	. "github.com/r7kamura/gospel"
+	"testing"
+)
+
+func TestHostname(t *testing.T) {
+	Describe(t, "ipaddress.Name", func() {
+		collector := &IpAddress{}
+
+		It("should have its own name", func() {
+			Expect(collector.Name()).To(Equal, "ipaddress")
+		})
+	})
+
+	Describe(t, "verity.Collector.IpAddress.Collect", func() {
+		collector := &IpAddress{}
+		result, _ := collector.Collect()
+		ipaddress := "10.0.2.15"
+
+		It("should be able to collect ipaddress", func() {
+			Expect(result.(string)).To(Equal, ipaddress)
+		})
+	})
+}

--- a/ipv6address/ipv6address.go
+++ b/ipv6address/ipv6address.go
@@ -1,26 +1,26 @@
-package ipaddress
+package ipv6address
 
 import (
 	"errors"
 	"net"
 )
 
-type IpAddress struct{}
+type Ipv6Address struct{}
 
-const name = "ipaddress"
+const name = "ipv6address"
 
-func (self *IpAddress) Name() string {
+func (self *Ipv6Address) Name() string {
 	return name
 }
 
-func (self *IpAddress) Collect() (result interface{}, err error) {
-	ipaddress, err := externalIpAddress()
-	result = ipaddress
+func (self *Ipv6Address) Collect() (result interface{}, err error) {
+	ipv6address, err := externalIpv6Address()
+	result = ipv6address
 
 	return
 }
 
-func externalIpAddress() (string, error) {
+func externalIpv6Address() (string, error) {
 	ifaces, err := net.Interfaces()
 
 	if err != nil {
@@ -47,9 +47,8 @@ func externalIpAddress() (string, error) {
 			if ip == nil || ip.IsLoopback() {
 				continue
 			}
-			ip = ip.To4()
-			if ip == nil {
-				// not an ipv4 address
+			if ip.To4() != nil {
+				// ipv4 address
 				continue
 			}
 			return ip.String(), nil

--- a/ipv6address/ipv6address_test.go
+++ b/ipv6address/ipv6address_test.go
@@ -1,0 +1,16 @@
+package ipv6address
+
+import (
+	. "github.com/r7kamura/gospel"
+	"testing"
+)
+
+func TestIpv6Address(t *testing.T) {
+	Describe(t, "ipv6address.Name", func() {
+		collector := &Ipv6Address{}
+
+		It("should have its own name", func() {
+			Expect(collector.Name()).To(Equal, "ipv6address")
+		})
+	})
+}

--- a/macaddress/macaddress.go
+++ b/macaddress/macaddress.go
@@ -1,26 +1,26 @@
-package ipaddress
+package macaddress
 
 import (
 	"errors"
 	"net"
 )
 
-type IpAddress struct{}
+type MacAddress struct{}
 
-const name = "ipaddress"
+const name = "macaddress"
 
-func (self *IpAddress) Name() string {
+func (self *MacAddress) Name() string {
 	return name
 }
 
-func (self *IpAddress) Collect() (result interface{}, err error) {
-	ipaddress, err := externalIpAddress()
-	result = ipaddress
+func (self *MacAddress) Collect() (result interface{}, err error) {
+	macaddress, err := macAddress()
+	result = macaddress
 
 	return
 }
 
-func externalIpAddress() (string, error) {
+func macAddress() (string, error) {
 	ifaces, err := net.Interfaces()
 
 	if err != nil {
@@ -44,15 +44,10 @@ func externalIpAddress() (string, error) {
 			case *net.IPAddr:
 				ip = v.IP
 			}
-			if ip == nil || ip.IsLoopback() {
+			if ip == nil || ip.IsLoopback() || ip.To4() == nil {
 				continue
 			}
-			ip = ip.To4()
-			if ip == nil {
-				// not an ipv4 address
-				continue
-			}
-			return ip.String(), nil
+			return iface.HardwareAddr.String(), nil
 		}
 	}
 	return "", errors.New("not connected to the network")

--- a/macaddress/macaddress_test.go
+++ b/macaddress/macaddress_test.go
@@ -1,0 +1,16 @@
+package macaddress
+
+import (
+	. "github.com/r7kamura/gospel"
+	"testing"
+)
+
+func TestMacAddress(t *testing.T) {
+	Describe(t, "macaddress.Name", func() {
+		collector := &IpAddress{}
+
+		It("should have its own name", func() {
+			Expect(collector.Name()).To(Equal, "macaddress")
+		})
+	})
+}

--- a/macaddress/macaddress_test.go
+++ b/macaddress/macaddress_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestMacAddress(t *testing.T) {
 	Describe(t, "macaddress.Name", func() {
-		collector := &IpAddress{}
+		collector := &MacAddress{}
 
 		It("should have its own name", func() {
 			Expect(collector.Name()).To(Equal, "macaddress")

--- a/network/network.go
+++ b/network/network.go
@@ -1,0 +1,98 @@
+package network
+
+import (
+	"net"
+)
+
+type Network struct{}
+
+const name = "network"
+
+func (self *Network) Name() string {
+	return name
+}
+
+func (self *Network) Collect() (result interface{}, err error) {
+	result, err = getNetworkInfo()
+	return
+}
+
+func getNetworkInfo() (networkInfo map[string]interface{}, err error) {
+	ifaces, err := net.Interfaces()
+
+	if err != nil {
+		return
+	}
+
+	networkInfo = make(map[string]interface{})
+	var interfaces = make(map[string]interface{})
+	networkInfo["interfaces"] = interfaces
+
+	for _, iface := range ifaces {
+		newIface := make(map[string]interface{})
+		flags := getFlags(iface)
+		addresses, _ := getAddresses(iface)
+		newIface["mtu"] = iface.MTU
+		newIface["flags"] = flags
+		newIface["addresses"] = addresses
+		interfaces[iface.Name] = newIface
+	}
+
+	return
+}
+
+func getFlags(iface net.Interface) (flags []string) {
+	if iface.Flags&net.FlagUp != 0 {
+		flags = append(flags, "UP")
+	}
+	if iface.Flags&net.FlagLoopback != 0 {
+		flags = append(flags, "LOOPBACK")
+	}
+	if iface.Flags&net.FlagBroadcast != 0 {
+		flags = append(flags, "BROADCASE")
+	}
+	if iface.Flags&net.FlagMulticast != 0 {
+		flags = append(flags, "MULTICAST")
+	}
+	if iface.Flags&net.FlagPointToPoint != 0 {
+		flags = append(flags, "POINTTOPOINT")
+	}
+
+	return
+}
+
+func getAddresses(iface net.Interface) (addresses map[string]interface{}, err error) {
+	addresses = make(map[string]interface{})
+
+	addrs, err := iface.Addrs()
+	if err != nil {
+		return nil, err
+	}
+	for _, addr := range addrs {
+		var ip net.IP
+		addressInfo := make(map[string]string)
+		switch v := addr.(type) {
+		case *net.IPNet:
+			ip = v.IP
+		case *net.IPAddr:
+			ip = v.IP
+		}
+
+		netmask := ip.DefaultMask()
+		if netmask != nil {
+			addressInfo["family"] = "inet"
+		} else {
+			addressInfo["family"] = "inet6"
+		}
+		addresses[ip.String()] = addressInfo
+	}
+
+	mac := iface.HardwareAddr
+	if mac != nil {
+		addressInfo := make(map[string]string)
+		addressInfo["family"] = "lladdr"
+		addresses[mac.String()] = addressInfo
+	}
+
+	return
+}

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -7,10 +7,35 @@ import (
 
 func TestNetwork(t *testing.T) {
 	Describe(t, "network.Name", func() {
-		collector := &IpAddress{}
+		collector := &Network{}
 
 		It("should have its own name", func() {
 			Expect(collector.Name()).To(Equal, "network")
+		})
+	})
+
+	Describe(t, "network.Collect", func() {
+		collector := &Network{}
+		result, _ := collector.Collect()
+
+		It("should have interfaces attribute", func() {
+			_, ok := result.(map[string]interface{})["interfaces"]
+			Expect(ok).To(Equal, true)
+		})
+
+		It("should have loopback interface info", func() {
+			interfaces, _ := result.(map[string]interface{})["interfaces"]
+			lo, ok := interfaces.(map[string]interface{})["lo"]
+			Expect(ok).To(Equal, true)
+
+			_, ok = lo.(map[string]interface{})["mtu"]
+			Expect(ok).To(Equal, true)
+
+			addresses, ok := lo.(map[string]interface{})["addresses"]
+			Expect(ok).To(Equal, true)
+
+			_, ok = addresses.(map[string]interface{})["127.0.0.1"]
+			Expect(ok).To(Equal, true)
 		})
 	})
 }

--- a/network/network_test.go
+++ b/network/network_test.go
@@ -1,0 +1,16 @@
+package network
+
+import (
+	. "github.com/r7kamura/gospel"
+	"testing"
+)
+
+func TestNetwork(t *testing.T) {
+	Describe(t, "network.Name", func() {
+		collector := &IpAddress{}
+
+		It("should have its own name", func() {
+			Expect(collector.Name()).To(Equal, "network")
+		})
+	})
+}


### PR DESCRIPTION
In reference to Ohai, I added the following collectors.
- ipaddress
- ipv6address
- macaddress
- network

The `network` collector collects information about the address of each interface, MTU, the flags.
It is the output in the VM.

``` json
{
    "network": {
        "interfaces": {
            "eth0": {
                "addresses": {
                    "08:00:27:60:fc:47": {
                        "family": "lladdr"
                    }, 
                    "10.0.2.15": {
                        "family": "inet"
                    }, 
                    "fe80::a00:27ff:fe60:fc47": {
                        "family": "inet6"
                    }
                }, 
                "flags": [
                    "UP", 
                    "BROADCASE", 
                    "MULTICAST"
                ], 
                "mtu": 1500
            }, 
            "lo": {
                "addresses": {
                    "127.0.0.1": {
                        "family": "inet"
                    }, 
                    "::1": {
                        "family": "inet6"
                    }
                }, 
                "flags": [
                    "UP", 
                    "LOOPBACK"
                ], 
                "mtu": 16436
            }
        }
    }
}
```
