### PR TITLE
Add `Distro()` into util package

### DIFF
--- a/packages/packages.go
+++ b/packages/packages.go
@@ -22,7 +22,7 @@ func (self *Packages) Collect() (result interface{}, err error) {
 }
 
 func getInstalledPackages() (packages []string, err error) {
-	distro, err := util.Distro()
+	format, err := util.PackageFormat()
 
 	if err != nil {
 		return
@@ -31,9 +31,9 @@ func getInstalledPackages() (packages []string, err error) {
 	var command string
 	var args []string
 
-	switch distro {
-	case "rhel":
-		command = "rpm"
+	switch format {
+	case "rpm":
+		command = format
 		args = []string{"-qa"}
 	default:
 		err = errors.New(fmt.Sprintf("unsupported distribution: %s", distro))

--- a/util/util.go
+++ b/util/util.go
@@ -3,8 +3,10 @@ package util
 import (
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"runtime"
+	"strings"
 )
 
 func Platform() (result string) {
@@ -12,18 +14,42 @@ func Platform() (result string) {
 	return
 }
 
-func Distro() (result string, err error) {
+func PackageFormat() (result string, err error) {
 	platform := Platform()
 
 	switch platform {
 	case "linux":
 		if _, err := os.Stat("/etc/redhat-release"); err == nil {
-			result = "rhel"
+			result = "rpm"
 		} else {
 			err = errors.New("unsupported distribution")
 		}
 	default:
 		err = errors.New(fmt.Sprint("unsupported platform: %s", platform))
+	}
+
+	return
+}
+
+func Distro() (result string, err error) {
+	format, err := PackageFormat()
+
+	if err != nil {
+		return
+	}
+
+	switch format {
+	case "rpm":
+		var data []byte
+
+		data, err = ioutil.ReadFile("/etc/redhat-release")
+		if err != nil {
+			return
+		}
+
+		result = strings.TrimRight(string(data), "\n")
+	default:
+		err = errors.New(fmt.Sprint("unsupported package format: %s", format))
 	}
 
 	return

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -13,12 +13,25 @@ func TestPlatform(t *testing.T) {
 	}
 }
 
-func TestDistro(t *testing.T) {
-	actual, err := Distro()
-	expected := "rhel"
+func TestPackageFormat(t *testing.T) {
+	actual, err := PackageFormat()
+	expected := "rpm"
 
 	if err != nil {
-		t.Errorf("it should be able to retrieve distro name: %s", err)
+		t.Errorf("it should be able to retrieve package format: %s", err)
+	}
+
+	if actual != expected {
+		t.Errorf("got %v\nexpected %v", actual, expected)
+	}
+}
+
+func TestDistro(t *testing.T) {
+	actual, err := Distro()
+	expected := "CentOS release 6.5 (Final)"
+
+	if err != nil {
+		t.Errorf("it should be able to retrieve package format: %s", err)
 	}
 
 	if actual != expected {


### PR DESCRIPTION
This PR enables us to retrieve distribution name.
